### PR TITLE
Corrected scope names

### DIFF
--- a/scopes.md
+++ b/scopes.md
@@ -28,8 +28,8 @@ Orders
 
 Permissions required: `Orders`, `OrderStatuses`
 
-* `read_order` - View order data
-* `order` - View and change order data; supercedes `read_order` if specified together
+* `read_orders` - View order data
+* `orders` - View and change order data; supercedes `read_order` if specified together
 
 Applies to:
 


### PR DESCRIPTION
Order scopes were singular but should be plural - caused some confusion with requesting tokens with that scope